### PR TITLE
Fix get example in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ public function get($key, $default = null)
 
 ```php
 $arrays->set('movies.the-thin-red-line.title', 'The Thin Red Line');
+
+$arrays->get('movies.the-thin-red-line.title'); // 'The Thin Red Line'
 ```
 
 ##### <a name="arrays_has"></a> Method: `has()`


### PR DESCRIPTION
I just saw an error in the example of the "get()" description in the readme.md

